### PR TITLE
Let the changes made by post-fs-data.sh be loaded right away without another boot

### DIFF
--- a/common/post-fs-data.sh
+++ b/common/post-fs-data.sh
@@ -9,20 +9,22 @@ exec &> $MODDIR/post-fs-data.log
 
 set -x
 
+if [ -f "/magisk/.core/bin/resetprop" ]; then
+  RESETPROP="/magisk/.core/bin/resetprop"
+elif [ -f "/data/magisk/resetprop" ]; then
+  RESETPROP="/data/magisk/resetprop"
+else
+  exit 1
+fi
+
 get_prop() {
     cat /system/build.prop | sed -n "s/^$1=//p"
 }
 
 set_prop() {
     [ "`get_prop ro.product.name`" == "$1" ] || [ "`get_prop ro.product.device`" == "$1" ] || [ "`get_prop ro.build.product`" == "$1" ] && {
-        cat > $MODDIR/system.prop <<EOF
-# This file will be read by resetprop
-# Example: Change dpi
-# ro.sf.lcd_density=320
-ro.build.description=$1-user $2 $3 $4 release-keys
-ro.build.fingerprint=Xiaomi/$1/$1:$2/$3/$4:user/release-keys
-EOF
-        exit
+        $RESETPROP "ro.build.description" "$1-user $2 $3 $4 release-keys"
+        $RESETPROP "ro.build.fingerprint" "Xiaomi/$1/$1:$2/$3/$4:user/release-keys"
     }
 }
 

--- a/config.sh
+++ b/config.sh
@@ -2,21 +2,21 @@
 #
 # Magisk
 # by topjohnwu
-# 
+#
 # This is a template zip for developers
 #
 ##########################################################################################
 ##########################################################################################
-# 
+#
 # Instructions:
-# 
+#
 # 1. Place your files into system folder (delete the placeholder file)
 # 2. Fill in your module's info into module.prop
 # 3. Configure the settings in this file (common/config.sh)
 # 4. For advanced features, add shell commands into the script files under common:
 #    post-fs-data.sh, service.sh
 # 5. For changing props, add your additional/modified props into common/system.prop
-# 
+#
 ##########################################################################################
 
 ##########################################################################################
@@ -34,7 +34,7 @@ MODID=xiaomi-safetynet-fix
 AUTOMOUNT=false
 
 # Set to true if you need to load system.prop
-PROPFILE=true
+PROPFILE=false
 
 # Set to true if you need post-fs-data script
 POSTFSDATA=true
@@ -98,5 +98,4 @@ set_permissions() {
   # set_perm  $MODPATH/system/bin/app_process32   0       2000    0755         u:object_r:zygote_exec:s0
   # set_perm  $MODPATH/system/bin/dex2oat         0       2000    0755         u:object_r:dex2oat_exec:s0
   # set_perm  $MODPATH/system/lib/libart.so       0       0       0644
-  sh $MODPATH/post-fs-data.sh
 }


### PR DESCRIPTION
I know you try to run the post-fs-data.sh immediately after installation. But it is still a little weird that, all the changes in system.prop, the properties written by post-fs-data.sh during boot, will **be loaded at next boot**. How about dropping the system.prop and loading the properties by post-fs-data.sh directly?